### PR TITLE
Disable event propagation on lasso button click

### DIFF
--- a/src/lasso-control.ts
+++ b/src/lasso-control.ts
@@ -34,9 +34,10 @@ export class LassoControl extends L.Control {
         button.title = 'Toggle Lasso';
         button.setAttribute('role', 'button');
         button.setAttribute('aria-label', button.title);
-
+        
         L.DomEvent.addListener(button, 'click', this.toggle, this);
-
+        L.DomEvent.disableClickPropagation(button);
+        
         return container;
     }
 

--- a/src/lasso-control.ts
+++ b/src/lasso-control.ts
@@ -34,10 +34,10 @@ export class LassoControl extends L.Control {
         button.title = 'Toggle Lasso';
         button.setAttribute('role', 'button');
         button.setAttribute('aria-label', button.title);
-        
+
         L.DomEvent.addListener(button, 'click', this.toggle, this);
         L.DomEvent.disableClickPropagation(button);
-        
+
         return container;
     }
 


### PR DESCRIPTION
Currently, clicking on the lasso control button propagates click events to the map, leading to undesired behavior.  This commit uses L.DomEvent.disableClickPropagation to address the issue.  Leaflet's standard Zoom Control uses the same technique.