### PR TITLE
Add invalid bounds checking

### DIFF
--- a/src/calc.ts
+++ b/src/calc.ts
@@ -65,7 +65,9 @@ export function getLayersInPolygon(polygon: L.Polygon, layers: L.Layer[], option
             layerGeometry = layerToGeoJSONGeometry(layer, options);
             layerBounds = geoJSONGeometryToBounds(layerGeometry);
         }
-
+        // some bounds may be invalid, for example for empty polylines
+        if (!layerBounds?.isValid())
+            return false;
         const boundsResult = options.intersect ?
             polygonBounds.intersects(layerBounds) :
             polygonBounds.contains(layerBounds);


### PR DESCRIPTION
In some cases there can be layers without bounds, for example, empty polylines (in general - paths) made for dynamic changes or workarounds, like https://github.com/makinacorpus/Leaflet.TextPath/issues/83. This fix prevents later exceptions on bounds relation calculation.