### PR TITLE
Stop event propagation on mouse events

### DIFF
--- a/src/lasso-handler.ts
+++ b/src/lasso-handler.ts
@@ -91,6 +91,8 @@ export class LassoHandler extends L.Handler {
     }
 
     private onMapMouseDown(event: Event) {
+        event.stopPropagation();
+        
         let event2 = this.eventToMouseEvent('down', event);
         if (!event2) {
             return;
@@ -121,6 +123,8 @@ export class LassoHandler extends L.Handler {
     }
 
     private onDocumentMouseMove(event: Event) {
+        event.stopPropagation();
+        
         let event2 = this.eventToMouseEvent('move', event);
         if (!event2) {
             return;
@@ -145,7 +149,7 @@ export class LassoHandler extends L.Handler {
 
     private onDocumentMouseUp(event: MouseEvent | TouchEvent) {
         this.finish(event);
-
+        event.stopPropagation();
         event.preventDefault();
     }
 


### PR DESCRIPTION
I don't want the mouse events to propagate through to leaflet when using the lasso selection.

Concrete example:

1. lasso select geojson paths
2. select using lasso and click (shift to add to selection)
3. when clicking outside the selection this should trigger the leaflet click to deselect.

Without stopping the propagation, every lasso event triggers a leaflet mouse event. Maybe this should be configurable, but I can't think of a scenario when I would need the propagation?